### PR TITLE
Add Xquik OpenAPI spec example

### DIFF
--- a/specs/xquik.yaml
+++ b/specs/xquik.yaml
@@ -1,0 +1,130 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+  description: REST API for X automation workflows, API keys, tweet search, and webhooks.
+servers:
+  - url: https://xquik.com
+security:
+  - apiKey: []
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: API key passed with the x-api-key header.
+  schemas:
+    ApiKeyList:
+      type: object
+      properties:
+        apiKeys:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              prefix:
+                type: string
+    TweetSearchResponse:
+      type: object
+      properties:
+        tweets:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              text:
+                type: string
+              authorUsername:
+                type: string
+    WebhookCreateRequest:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          description: HTTPS endpoint that receives signed webhook events.
+        eventTypes:
+          type: array
+          items:
+            type: string
+          description: Event types to deliver.
+      required:
+        - url
+        - eventTypes
+    Webhook:
+      type: object
+      properties:
+        id:
+          type: string
+        url:
+          type: string
+          format: uri
+        eventTypes:
+          type: array
+          items:
+            type: string
+paths:
+  /api/v1/api-keys:
+    get:
+      summary: List API keys
+      description: List API keys for the authenticated Xquik account.
+      operationId: listApiKeys
+      responses:
+        "200":
+          description: API keys
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiKeyList"
+  /api/v1/x/tweets/search:
+    get:
+      summary: Search tweets
+      description: Search public X posts through Xquik.
+      operationId: searchTweets
+      parameters:
+        - name: query
+          in: query
+          required: true
+          description: Search query.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum tweets to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Tweet search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TweetSearchResponse"
+  /api/v1/webhooks:
+    post:
+      summary: Create webhook
+      description: Create a signed webhook endpoint.
+      operationId: createWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookCreateRequest"
+      responses:
+        "201":
+          description: Created webhook
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Webhook"


### PR DESCRIPTION
## Description

Adds `specs/xquik.yaml`, a compact OpenAPI 3.1 fixture for Xquik REST workflows. The fixture covers API-key auth, API key listing, tweet search, and webhook creation.

## Type of Change

- [x] Documentation update
- [ ] Test improvement

## Testing

- [x] Manual testing completed

Test results:

- Loaded `specs/xquik.yaml` through `github.com/getkin/kin-openapi/openapi3`.
- Extracted 3 operations through `pkg/openapi2mcp`: `listApiKeys`, `searchTweets`, and `createWebhook`.
- `go test ./pkg/openapi2mcp` is currently blocked by existing compile errors in `pkg/openapi2mcp/register_test.go`, where existing tests call `RegisterOpenAPITools` with the previous signature.

## Changes Made

- [x] Added: `specs/xquik.yaml` - OpenAPI 3.1 example spec with `x-api-key` header auth.

## Breaking Changes

None.

## Checklist

- [x] No sensitive data exposed in code or tests
- [x] Examples updated or added
- [x] Security implications considered and documented